### PR TITLE
orc8r_docker initial commit

### DIFF
--- a/orc8r_docker/README.md
+++ b/orc8r_docker/README.md
@@ -56,9 +56,7 @@ sudo openssl req -new -key fluentd.key -out fluentd.csr -subj "/C=NI/CN=fluentd.
 sudo openssl x509 -req -in fluentd.csr -CA certifier.pem -CAkey certifier.key -CAcreateserial -out fluentd.pem -days 3650 -sha256
 ```
 ##### Deploying the containers 
-
 Now start all the containers. Use the next docker-compose files as if you are just deploying for testing, for production you have to change the database username and password on the files at least. But this is meant to be used for tests. 
-In this files the database username is db_user, database password is db_password and the database name are db_name. Change that config with your owns. 
   There are 3 files are to be changed docker-compose-controller.yml,docker-compose-nms.yml,docker-compose-metrics.yml
   Do docker compose -f docker-compose-controller.yml up -d, docker compose -f docker-compose-metrics.yml up -d. 
 ##### Create the certs for the NMS.  

--- a/orc8r_docker/README.md
+++ b/orc8r_docker/README.md
@@ -1,0 +1,88 @@
+## Deploying the Orchestrators v1.8
+#### The documentation is meant to help you deploy the Magma core orchestrators for testing, not for production 
+##### Install Docker Engine (incl. Docker Compose)
+```
+sudo apt-get update
+sudo apt-get install ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+##### Now create some directories that we will be using on this installationmkdir -p /magma
+```
+mkdir -p /magma/certs
+mkdir -p /magma/postgres
+mkdir -p /magma/magmalte
+mkdir -p /magma/docker_ssl_proxy
+sudo wget https://raw.githubusercontent.com/magma/magma/v1.8/orc8r/cloud/docker/fluentd/conf/fluent.conf -P /magma/fluentd/conf/
+sudo wget https://raw.githubusercontent.com/magma/magma/v1.8/nms/docker/docker_ssl_proxy/proxy_ssl.conf -P /magma/docker_ssl_proxy
+git clone https://github.com/magma/magma.git
+cd magma
+git checkout v1.8
+sudo cp -R orc8r/cloud/docker/controller/ /magma/
+sudo cp -R orc8r/cloud/docker/fluentd /magma/
+sudo cp -R orc8r/cloud/docker/metrics-configs/ /magma/
+sudo cp -R nms/api /magma/magmalte/
+sudo cp -R nms/app /magma/magmalte/
+sudo cp -R nms/config /magma/magmalte/
+sudo cp -R nms/generated /magma/magmalte/
+sudo cp -R nms/scripts /magma/magmalte/
+sudo cp -R nms/server /magma/magmalte/
+sudo cp -R nms/shared /magma/magmalte/
+```
+##### Next get this script, it will help to create some of the certificates needed
+```
+sudo wget https://raw.githubusercontent.com/edaspb/Magma-Orchastrator-in-a-Docker-Swarm/master/scripts/certs.sh
+sudo chmod +x certs.sh
+sudo ./certs.sh
+sudo ls -lh /magma/certs/
+```
+###### Edit the script to adapt it to your own needs 
+Then you have to create the certs for the SSL on the docker nginx reverse proxy 
+```
+sudo openssl req -new -x509 -nodes -out /magma/docker_ssl_proxy/cert.pem -keyout /magma/docker_ssl_proxy/key.pem -days 365
+```
+Then create the certificate for the fluentd service, remember to change "yourdomain" by your own domain. 
+```
+cd /magma/certs/
+sudo openssl genrsa -out fluentd.key 2048
+sudo openssl req -new -key fluentd.key -out fluentd.csr -subj "/C=NI/CN=fluentd."yourdomain".com"
+sudo openssl x509 -req -in fluentd.csr -CA certifier.pem -CAkey certifier.key -CAcreateserial -out fluentd.pem -days 3650 -sha256
+```
+##### Deploying the containers 
+
+Now start all the containers. Use the next docker-compose files as if you are just deploying for testing, for production you have to change the database username and password on the files at least. But this is meant to be used for tests. 
+In this files the database username is db_user, database password is db_password and the database name are db_name. Change that config with your owns. 
+  There are 3 files are to be changed docker-compose-controller.yml,docker-compose-nms.yml,docker-compose-metrics.yml
+  Do docker compose -f docker-compose-controller.yml up -d, docker compose -f docker-compose-metrics.yml up -d. 
+##### Create the certs for the NMS.  
+For that you can enter to the controller container and create the admin certificate. To do that follow the command 
+```
+docker ps --format '{{.Names}}' # DISPLAYS CONTAINERS NAMES
+docker exec -it magma-controller-1 bash # ENTER TO THE CONTAINER THIS SHOULD BE THE NAME IF THE COMPOSE FILES ARE IN /MAGMA/
+#### FROM HERE THIS COMMANDS ARE TO CREATE THE CERTS####
+envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-admin -duration 3650 -cert /var/opt/magma/bin/admin_operator admin_operator
+openssl pkcs12 -export -out /var/opt/magma/bin/admin_operator.pfx -inkey /var/opt/magma/bin/admin_operator.key.pem -in /var/opt/magma/bin/admin_operator.pem
+## THIS WILL REQUEST A PASSWORD, YOU CAN SET UP A PASSWORD OR JUST PRESS ENTER TWICE.
+#### ENDING CREATING THE CERTS ####
+#### EXIT THE CONTAINER ####
+exit
+#### NOW COPY THE CERTS TO THE /magma/certs/ folder ####
+sudo docker cp magma-controller-1:/var/opt/magma/bin/admin_operator.key.pem /magma/certs/admin_operator.key.pem
+sudo docker cp magma-controller-1:/var/opt/magma/bin/admin_operator.pem /magma/certs/admin_operator.pem
+sudo docker cp magma-controller-1:/var/opt/magma/bin/admin_operator.pfx /magma/certs/admin_operator.pfx
+```
+After this host machine,go to file
+C:\Windows\System32\drivers\etc
+and edit host file as follows:
+
+ip address host.yourdomain.com yourdomain.com
+After this 
+you can access nms at
+https://host.yourdomain.com/nms

--- a/orc8r_docker/docker-compose-controller.yml
+++ b/orc8r_docker/docker-compose-controller.yml
@@ -1,0 +1,117 @@
+version: "3.7"
+
+services:
+  controller:
+    image: mehuljindalwavelabs/orc8r_controller
+    environment:
+      TEST_MODE: "0"
+      SERVICE_HOSTNAME: localhost
+      SQL_DRIVER: postgres
+      DATABASE_SOURCE: "dbname=db_name user=db_user password=db_password host=postgres sslmode=disable"
+      SQL_DIALECT: psql
+      SERVICE_REGISTRY_MODE: yaml
+      MAGMA_PRINT_GRPC_PAYLOAD: 0
+    volumes:
+      - /magma/certs:/var/opt/magma/certs
+      - /magma/controller/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf
+    links:
+      - fluentd
+    depends_on:
+      - fluentd
+    command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 && /usr/bin/supervisord"]
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.labels.controller == true]
+  nginx:
+    image: mehuljindalwavelabs/orc8r_nginx
+    ports:
+      - 7443:8443/tcp   # controller GRPC port
+      - 7444:8444/tcp  # Bootstrapper port
+      - 9443:9443/tcp  # API/controller port
+    environment:
+      CONTROLLER_HOSTNAME: controller.domain.com
+      PROXY_BACKENDS: controller  # Uses Docker internal DNS for controller
+      TEST_MODE: "0"
+      RESOLVER: "127.0.0.11"
+      SERVICE_REGISTRY_MODE: yaml
+      SSL_CERTIFICATE: "/var/opt/magma/certs/controller.crt"
+      SSL_CERTIFICATE_KEY: "/var/opt/magma/certs/controller.key"
+      SSL_CLIENT_CERTIFICATE: "/var/opt/magma/certs/certifier.pem"
+    volumes:
+      - /magma/certs:/var/opt/magma/certs
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.labels.controller == true]
+    depends_on:
+      - controller
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.1
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+    ports:
+      - 9200:9200
+      - 9300:9300
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+    deploy:
+      placement:
+        constraints: [node.labels.controller == true]
+
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.3.1
+    ports:
+      - 5601:5601
+    links:
+      - elasticsearch
+    deploy:
+      placement:
+        constraints: [node.labels.controller == true]
+
+
+  fluentd:
+    image: mehuljindalwavelabs/orc8r_fluentd
+    ports:
+      - 24224:24224
+      - 24224:24224/udp
+      - 24225:24225
+      - 24225:24225/udp
+    volumes:
+      - /magma/fluentd/conf:/fluentd/etc
+      - /magma/certs:/var/opt/magma/certs
+    deploy:
+      placement:
+        constraints: [node.labels.controller == true]
+
+  postgres:
+    image: postgres
+    # Default is 64mb
+    # Ref: https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container
+    shm_size: '8192mb'
+    ports:
+      - "5432:5432/tcp"
+    volumes:
+      - /magma/postgres:/var/lib/postgresql/data
+      #- pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: db_user
+      POSTGRES_PASSWORD: db_password
+      POSTGRES_DB: db_name
+    command:
+      - "postgres"
+      - "-c"
+      - "log_duration=true"
+#      - "-c"
+#      - "log_statement=all"
+#    restart: always
+    deploy:
+      placement:
+        constraints: [node.labels.controller == true]
+
+volumes:
+  elasticsearch:
+  #pgdata:

--- a/orc8r_docker/docker-compose-metrics.yml
+++ b/orc8r_docker/docker-compose-metrics.yml
@@ -1,0 +1,96 @@
+version: "3.7"
+
+services:
+  prometheus-cache:
+    image: facebookincubator/prometheus-edge-hub:1.1.0
+    ports:
+      - 9091:9091/tcp
+      - 9092:9092/tcp
+    command:
+      - '-limit=500000'
+      - '-grpc-port=9092'
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "20"
+        max-size: "100m"
+  prometheus:
+    image: prom/prometheus:v2.20.1
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - /magma/metrics-configs:/etc/prometheus:ro
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+    logging:    # This part is to avoid the logs to fill the disk
+      driver: "json-file"
+      options:
+        max-file: "20"
+        max-size: "100m"
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+
+  alertmanager:
+    image: prom/alertmanager
+    ports:
+      - 9093:9093/tcp
+    volumes:
+      - /magma/metrics-configs:/etc/alertmanager:ro
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+
+  prometheus-configurer:
+    image: facebookincubator/prometheus-configurer:1.0.0
+    volumes:
+      - /magma/metrics-configs:/etc/configs
+    command:
+      - '-port=9100'
+      - '-rules-dir=/etc/configs/alert_rules'
+      - '-prometheusURL=prometheus:9090'
+      - '-multitenant-label=networkID'
+      - '-restrict-queries'
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+
+  alertmanager-configurer:
+    image: facebookincubator/alertmanager-configurer:1.0.0
+    volumes:
+      - /magma/metrics-configs:/etc/configs
+    command:
+      - '-port=9101'
+      - '-alertmanager-conf=/etc/configs/alertmanager.yml'
+      - '-alertmanagerURL=alertmanager:9093'
+      - '-multitenant-label=networkID'
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+
+  user-grafana:
+    image: grafana/grafana:6.6.2
+    volumes:
+      - userGrafanaData:/var/lib/grafana
+    ports:
+      - 3000:3000/tcp
+    environment:
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_USERS_AUTO_ASSIGN_ORG=false
+      - GF_AUTH_PROXY_ENABLED=true
+      - GF_AUTH_PROXY_HEADER_NAME=X-WEBAUTH-USER
+      - GF_AUTH_PROXY_HEADER_PROPERTY=username
+      - GF_AUTH_PROXY_AUTO_SIGN_UP=false
+      - GF_SERVER_ROOT_URL=/grafana
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+
+volumes:
+  userGrafanaData:

--- a/orc8r_docker/docker-compose-nms.yml
+++ b/orc8r_docker/docker-compose-nms.yml
@@ -1,0 +1,55 @@
+version: "3.7"
+
+services:
+
+  magmalte:
+    image: mehuljindalwavelabs/nms-magmalte
+    ports:
+      - "8081:8081"
+    environment:
+      API_CERT_FILENAME: /run/secrets/api_cert
+      API_PRIVATE_KEY_FILENAME: /run/secrets/api_key
+      API_HOST: ${API_HOST:-nginx:9443}
+      PORT: 8081
+      HOST: 0.0.0.0
+      MYSQL_HOST: postgres
+      MYSQL_PORT: 5432
+      MYSQL_DB: db_name
+      MYSQL_USER: db_user
+      MYSQL_PASS: db_password
+      MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
+      MYSQL_DIALECT: postgres
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+    command: "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 -- yarn run start:dev"
+    volumes:
+      - /magma/magmalte/api:/usr/src/api
+      - /magma/magmalte/app:/usr/src/app
+      - /magma/magmalte/config:/usr/src/config
+      - /magma/magmalte/generated:/usr/src/generated
+      - /magma/magmalte/scripts:/usr/src/scripts
+      - /magma/magmalte/server:/usr/src/server
+      - /magma/magmalte/shared:/usr/src/shared
+    secrets:
+      - api_cert
+      - api_key
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+
+  nginx-proxy:
+    image: nginx
+    ports:
+      - "443:443"
+    volumes:
+      - /magma/docker_ssl_proxy:/etc/nginx/conf.d
+    depends_on:
+      - magmalte
+    deploy:
+      placement:
+        constraints: [node.labels.metrics == true]
+
+secrets:
+  api_cert:
+    file: /magma/certs/admin_operator.pem
+  api_key:
+    file: /magma/certs/admin_operator.key.pem


### PR DESCRIPTION
Guide to deploying Magma core orchestrators for testing, using docker. It includes instructions for setting up the necessary infrastructure using Docker, obtaining required scripts, generating certificates, configuring containers through docker compose files, and finalizing the deployment.